### PR TITLE
Bump `Pillow` version to `10.0.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Pillow==10.2.0
+Pillow==10.0.0
 requests>=2.26.0
 typing-extensions>=4.0.1
 aiohttp>=3.8.2,<=4.0


### PR DESCRIPTION
This is to address the `Image.ANTIALIAS` having an error.